### PR TITLE
add recall loss function for semantic segmentation task

### DIFF
--- a/nugraph/models/NuGraph2.py
+++ b/nugraph/models/NuGraph2.py
@@ -13,7 +13,7 @@ from torch.utils.checkpoint import checkpoint
 import matplotlib.pyplot as plt
 import seaborn as sn
 
-from ..util import FocalLoss
+from ..util import FocalLoss, RecallLoss
 
 Activation = nn.Tanh
 
@@ -370,7 +370,7 @@ class SemanticDecoder(nn.Module):
         for p in planes:
             self.net[p] = ClassLinear(node_features, 1, num_classes)
 
-        self.loss_func = FocalLoss(weight=weight, gamma=2)
+        self.loss_func = RecallLoss()
         self.acc_func = tm.Accuracy(task='multiclass',
                                     num_classes=num_classes)
         self.acc_func_classwise = tm.Accuracy(task='multiclass',

--- a/nugraph/util/RecallLoss.py
+++ b/nugraph/util/RecallLoss.py
@@ -1,0 +1,16 @@
+# as described in https://arxiv.org/abs/2106.14917
+
+import torch
+import torch.nn.functional as F
+from torchmetrics.functional.classification import multiclass_recall
+
+class RecallLoss(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input, target):
+        weight = 1 - multiclass_recall(input, target, num_classes=input.size(1), average='none')
+        CE = F.cross_entropy(input, target, reduction='none')
+        loss =  weight[target] * CE
+        return loss.mean()
+

--- a/nugraph/util/__init__.py
+++ b/nugraph/util/__init__.py
@@ -1,3 +1,4 @@
 # __init__.py
 from .FocalLoss import FocalLoss
+from .RecallLoss import RecallLoss
 from .FeatureNorm import FeatureNorm, FeatureNormMetric


### PR DESCRIPTION
Adding in Recall loss scheme, which gives us more balanced performance than the inverse-weighted focal loss. Currently only implementing for semantic segmentation, but we should explore using it for the other decoders as well.