### PR TITLE
fix bug in confusion matrix writing

### DIFF
--- a/scripts/test.py
+++ b/scripts/test.py
@@ -23,10 +23,7 @@ def configure():
 def test(args):
 
     # Load dataset
-    nudata = Data(args.data_path,
-                  batch_size=args.batch_size,
-                  planes=['u','v','y'],
-                  classes=['HIP','MIP','shower','michel','diffuse'],)
+    nudata = Data(args.data_path, batch_size=args.batch_size)
 
     model = Model.load_from_checkpoint(args.checkpoint, event_head=False)
 


### PR DESCRIPTION
When confusion matrices are calculated during the validation phase of training, we call `update` once per batch and then `compute` at the end of the epoch. However, it's also necessary to call `reset` afterwards to clear the matrix before moving onto the next epoch. Up until now, our code was missing that step, which caused the results from previous epochs to stick around and contribute to the matrix. That caused our confusion matrices to be overly pessimistic in later epochs.

This PR fixes that bug by adding in the missing `reset` calls, and also adds a few new hooks to save confusion matrices during model testing, and also adds name strings for each decoder and fixes a couple of erroneous type hints. The `test.py` script is also updated to reflect some changes to the data module that hadn't been propagated over.