### PR TITLE
hotfix for auto-device selection

### DIFF
--- a/nugraph/util/scriptutils.py
+++ b/nugraph/util/scriptutils.py
@@ -4,8 +4,15 @@ from pynvml.smi import nvidia_smi
 def configure_device(cpu: bool = False) -> tuple[str, str | list[int]]:
     if not cpu:
         try:
+            # query GPU information using pynvml
             nvsmi = nvidia_smi.getInstance()
             info = nvsmi.DeviceQuery('index,memory.free')['gpu']
+
+            # if there aren't multiple GPUs, don't do anything
+            if len(info) < 2:
+                return 'auto', 'auto'
+
+            # if there are multiple GPUs, select the one with the most memory
             info.sort(key=lambda m: m['fb_memory_usage']['free'], reverse=True)
             return 'auto', [int(info[0]['minor_number'])]
         except:


### PR DESCRIPTION
previous automatic GPU selection works on Heimdall but doesn't play nice with SLURM environments like the Wilson cluster. this change will fix the logic for single-GPU traning, we probably need a longterm solution for multi-GPU training