### PR TITLE
default to balanced data sampling

### DIFF
--- a/nugraph/data/H5DataModule.py
+++ b/nugraph/data/H5DataModule.py
@@ -182,7 +182,7 @@ class H5DataModule(LightningDataModule):
                           help='Max number of training batches to be used')
         data.add_argument('--limit_val_batches', type=int, default=None,
                           help='Max number of validation batches to be used')
-        data.add_argument('--shuffle', type=str, default='random',
+        data.add_argument('--shuffle', type=str, default='balance',
                           help='Dataset shuffling scheme to use')
         data.add_argument('--balance-frac', type=float, default=0.1,
                           help='Fraction of dataset to use for workload balancing')


### PR DESCRIPTION
tests indicate balanced data sampling is more memory-efficient, so switch to using it by default!

see peak memory usage during network training with random shuffling (grey) and balanced shuffling (blue):
![data shuffling comparison](https://github.com/exatrkx/NuGraph/assets/39996356/52a4ee57-9e9f-445f-91b6-676c8b05ba59)