### PR TITLE
add testing output to training metrics

### DIFF
--- a/notebooks/train.ipynb
+++ b/notebooks/train.ipynb
@@ -135,7 +135,8 @@
     "                     max_epochs=80,\n",
     "                     logger=logger,\n",
     "                     callbacks=callbacks)\n",
-    "trainer.fit(nugraph, datamodule=nudata)"
+    "trainer.fit(nugraph, datamodule=nudata)\n",
+    "trainer.test(datamodule=nudata)"
    ]
   },
   {

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -89,6 +89,7 @@ def train(args):
                          callbacks=callbacks, plugins=plugins)
 
     trainer.fit(model, datamodule=nudata, ckpt_path=args.resume)
+    trainer.test(datamodule=nudata)
 
 if __name__ == '__main__':
     args = configure()


### PR DESCRIPTION
call `trainer.test` at the end of training, which makes sure testing metrics are added to tensorboard, since those are the ones we use in the paper. it saves us having to run these metrics manually down the road.