### PR TITLE
restore returning of loss value

### DIFF
--- a/nugraph/models/NuGraph2.py
+++ b/nugraph/models/NuGraph2.py
@@ -188,6 +188,7 @@ class NuGraph2(LightningModule):
             self.log_dict(metrics, batch_size=batch.num_graphs)
         self.log('loss/train', total_loss, batch_size=batch.num_graphs, prog_bar=True)
         self.log_memory(batch, 'train')
+        return total_loss
 
     def validation_step(self,
                         batch,


### PR DESCRIPTION
PR #35 erroneously removed the returning of the loss value in `training_step`, which completely tanks model training. this PR restores that line and restores training functionality.