### PR TITLE
single-layer edge attention convolutions

### DIFF
--- a/notebooks/train.ipynb
+++ b/notebooks/train.ipynb
@@ -70,15 +70,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "db0d2c7d-b5de-4bcf-afd7-86bbfdfae49f",
    "metadata": {},
    "outputs": [],
    "source": [
     "nugraph = ng.models.NuGraph2(\n",
     "    in_features=4,\n",
-    "    node_features=64,\n",
-    "    sp_features=16,\n",
+    "    planar_features=64,\n",
+    "    nexus_features=16,\n",
     "    vertex_features=64,\n",
     "    planes=nudata.planes,\n",
     "    semantic_classes=nudata.semantic_classes,\n",

--- a/nugraph/models/NuGraph2.py
+++ b/nugraph/models/NuGraph2.py
@@ -22,8 +22,8 @@ class NuGraph2(LightningModule):
     inference, and compute training metrics."""
     def __init__(self,
                  in_features: int = 4,
-                 node_features: int = 8,
-                 sp_features: int = 8,
+                 planar_features: int = 8,
+                 nexus_features: int = 8,
                  vertex_features: int = 32,
                  planes: list[str] = ['u','v','y'],
                  semantic_classes: list[str] = ['MIP','HIP','shower','michel','diffuse'],
@@ -48,18 +48,18 @@ class NuGraph2(LightningModule):
         self.lr = lr
 
         self.encoder = Encoder(in_features,
-                               node_features,
+                               planar_features,
                                planes,
                                semantic_classes)
 
         self.plane_net = PlaneNet(in_features,
-                                  node_features,
+                                  planar_features,
                                   len(semantic_classes),
                                   planes,
                                   checkpoint=checkpoint)
 
-        self.nexus_net = NexusNet(node_features,
-                                  sp_features,
+        self.nexus_net = NexusNet(planar_features,
+                                  nexus_features,
                                   len(semantic_classes),
                                   planes,
                                   checkpoint=checkpoint)
@@ -68,7 +68,7 @@ class NuGraph2(LightningModule):
 
         if event_head:
             self.event_decoder = EventDecoder(
-                node_features,
+                planar_features,
                 planes,
                 semantic_classes,
                 event_classes)
@@ -76,21 +76,21 @@ class NuGraph2(LightningModule):
 
         if semantic_head:
             self.semantic_decoder = SemanticDecoder(
-                node_features,
+                planar_features,
                 planes,
                 semantic_classes)
             self.decoders.append(self.semantic_decoder)
 
         if filter_head:
             self.filter_decoder = FilterDecoder(
-                node_features,
+                planar_features,
                 planes,
                 semantic_classes)
             self.decoders.append(self.filter_decoder)
             
         if vertex_head:
             self.vertex_decoder = VertexDecoder(
-                node_features,
+                planar_features,
                 vertex_features,
                 planes,
                 semantic_classes)
@@ -258,10 +258,10 @@ class NuGraph2(LightningModule):
     def add_model_args(parser: ArgumentParser) -> ArgumentParser:
         '''Add argparse argpuments for model structure'''
         model = parser.add_argument_group('model', 'NuGraph2 model configuration')
-        model.add_argument('--node-feats', type=int, default=64,
-                           help='Hidden dimensionality of 2D node convolutions')
-        model.add_argument('--sp-feats', type=int, default=16,
-                           help='Hidden dimensionality of spacepoint convolutions')
+        model.add_argument('--planar-feats', type=int, default=64,
+                           help='Hidden dimensionality of planar convolutions')
+        model.add_argument('--nexus-feats', type=int, default=16,
+                           help='Hidden dimensionality of nexus convolutions')
         model.add_argument('--vertex-feats', type=int, default=32,
                            help='Hidden dimensionality of vertex decoder')
         model.add_argument('--event', action='store_true', default=False,

--- a/nugraph/models/nexus.py
+++ b/nugraph/models/nexus.py
@@ -10,25 +10,25 @@ from .linear import ClassLinear
 
 class NexusDown(MessagePassing):
     def __init__(self,
-                 node_features: int,
-                 sp_features: int,
+                 planar_features: int,
+                 nexus_features: int,
                  num_classes: int,
                  aggr: str = 'mean'):
         super().__init__(node_dim=0, aggr=aggr, flow='target_to_source')
 
         self.edge_net = nn.Sequential(
-            ClassLinear(node_features+sp_features,
+            ClassLinear(planar_features+nexus_features,
                         1,
                         num_classes),
             nn.Softmax(dim=1))
 
         self.node_net = nn.Sequential(
-            ClassLinear(node_features+sp_features,
-                        node_features,
+            ClassLinear(planar_features+nexus_features,
+                        planar_features,
                         num_classes),
             nn.Tanh(),
-            ClassLinear(node_features,
-                        node_features,
+            ClassLinear(planar_features,
+                        planar_features,
                         num_classes),
             nn.Tanh())
 
@@ -44,8 +44,8 @@ class NexusDown(MessagePassing):
 class NexusNet(nn.Module):
     '''Module to project to nexus space and mix detector planes'''
     def __init__(self,
-                 node_features: int,
-                 sp_features: int,
+                 planar_features: int,
+                 nexus_features: int,
                  num_classes: int,
                  planes: list[str],
                  aggr: str = 'mean',
@@ -57,19 +57,19 @@ class NexusNet(nn.Module):
         self.nexus_up = SimpleConv(node_dim=0)
 
         self.nexus_net = nn.Sequential(
-            ClassLinear(len(planes)*node_features,
-                        sp_features,
+            ClassLinear(len(planes)*planar_features,
+                        nexus_features,
                         num_classes),
             nn.Tanh(),
-            ClassLinear(sp_features,
-                        sp_features,
+            ClassLinear(nexus_features,
+                        nexus_features,
                         num_classes),
             nn.Tanh())
 
         self.nexus_down = nn.ModuleDict()
         for p in planes:
-            self.nexus_down[p] = NexusDown(node_features,
-                                           sp_features,
+            self.nexus_down[p] = NexusDown(planar_features,
+                                           nexus_features,
                                            num_classes,
                                            aggr)
 

--- a/nugraph/models/plane.py
+++ b/nugraph/models/plane.py
@@ -14,24 +14,24 @@ class MessagePassing2D(MessagePassing):
 
     def __init__(self,
                  in_features: int,
-                 node_features: int,
+                 planar_features: int,
                  num_classes: int,
                  aggr: str = 'add'):
         super().__init__(node_dim=0, aggr=aggr)
 
         self.edge_net = nn.Sequential(
-            ClassLinear(2 * (in_features + node_features),
+            ClassLinear(2 * (in_features + planar_features),
                         1,
                         num_classes),
             nn.Softmax(dim=1))
 
         self.node_net = nn.Sequential(
-            ClassLinear(2 * (in_features + node_features),
-                        node_features,
+            ClassLinear(2 * (in_features + planar_features),
+                        planar_features,
                         num_classes),
             nn.Tanh(),
-            ClassLinear(node_features,
-                        node_features,
+            ClassLinear(planar_features,
+                        planar_features,
                         num_classes),
             nn.Tanh())
 
@@ -48,7 +48,7 @@ class PlaneNet(nn.Module):
     '''Module to convolve within each detector plane'''
     def __init__(self,
                  in_features: int,
-                 node_features: int,
+                 planar_features: int,
                  num_classes: int,
                  planes: list[str],
                  aggr: str = 'add',
@@ -60,7 +60,7 @@ class PlaneNet(nn.Module):
         self.net = nn.ModuleDict()
         for p in planes:
             self.net[p] = MessagePassing2D(in_features,
-                                           node_features,
+                                           planar_features,
                                            num_classes,
                                            aggr)
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -42,8 +42,8 @@ def train(args):
 
     if args.name is not None and args.logdir is not None and args.resume is None:
         model = Model(in_features=4,
-                      node_features=args.node_feats,
-                      sp_features=args.sp_feats,
+                      planar_features=args.planar_feats,
+                      nexus_features=args.nexus_feats,
                       vertex_features=args.vertex_feats,
                       planes=nudata.planes,
                       semantic_classes=nudata.semantic_classes,


### PR DESCRIPTION
until now, the categorical cross-attention mechanism utilised in the planar and nexus blocks was a two-layer MLP, which convolved down from the number of planar features $N_{p}$ to an edge embedding with size $N_{e}$, then applied a non-linear activation before convolving down to a single score per category. the nominal size of this edge feature space $N_{e}$ was 16.

i recently performed some ablation studies for the NuGraph2 paper draft, and discovered that network performance was largely insensitive to the choice of $N_{e}$ – in fact, reducing $N_{e}$ down to 1 didn't really hurt network performance at all. that made me wonder whether learning quadratic information was actually necessary for the attention mechanism at all, so i reduced the categorical cross-attention blocks down to a single layer that convolved from $N_{p}$ directly down to 1.

i trained a network with this model variant, and found that my suspicion was correct – using a single linear layer gives identical performance to using a two-layer MLP. see comparisons between the older two-layer (blue) and the newer single-layer (orange) for filter recall:

![filter recall](https://github.com/exatrkx/NuGraph/assets/39996356/874f2cc9-cf09-4af9-8cf9-319d55abbf68)

and semantic recall:
![semantic recall](https://github.com/exatrkx/NuGraph/assets/39996356/067340ce-39d0-407b-897a-179638e7a1f3)

this change reduces the overall number of network parameters from 410K to 360K, a reduction of more than 10%, without sacrificing any performance. the benefits are pretty clear, so i'm merging this change back into the main branch.