### PR TITLE
fix flipped axis labels for confusion matrices

### DIFF
--- a/nugraph/models/decoders.py
+++ b/nugraph/models/decoders.py
@@ -70,8 +70,8 @@ class DecoderBase(nn.Module, ABC):
                    vmin=0, vmax=1,
                    annot=True)
         plt.ylim(0, len(self.classes))
-        plt.xlabel('Assigned label')
-        plt.ylabel('True label')
+        plt.xlabel('True label')
+        plt.ylabel('Assigned label')
         return fig
 
     def on_epoch_end(self,


### PR DESCRIPTION
"True label" and "Assigned label" labels were incorrectly flipped in confusion matrices; this PR swaps them.