### PR TITLE
Revert "fix flipped axis labels for confusion matrices"

### DIFF
--- a/nugraph/models/decoders.py
+++ b/nugraph/models/decoders.py
@@ -70,8 +70,8 @@ class DecoderBase(nn.Module, ABC):
                    vmin=0, vmax=1,
                    annot=True)
         plt.ylim(0, len(self.classes))
-        plt.xlabel('True label')
-        plt.ylabel('Assigned label')
+        plt.xlabel('Assigned label')
+        plt.ylabel('True label')
         return fig
 
     def on_epoch_end(self,


### PR DESCRIPTION
This reverts commit 1a7e998d94380582f5d804acf4955292251b4c0c.

nevermind – the axes were actually correct to begin with 🙃