### PR TITLE
Update for PyG 2.5

### DIFF
--- a/nugraph/models/nugraph2/NuGraph2.py
+++ b/nugraph/models/nugraph2/NuGraph2.py
@@ -257,10 +257,6 @@ class NuGraph2(LightningModule):
                            help='Maximum number of epochs to train for')
         model.add_argument('--learning-rate', type=float, default=0.001,
                            help='Max learning rate during training')
-        train.add_argument('--clip-gradients', type=float, default=None,
-                           help='Maximum value to clip gradient norm')
-        train.add_argument('--gamma', type=float, default=2,
-                           help='Focal loss gamma parameter')
         return parser
 
     @classmethod

--- a/nugraph/models/nugraph2/nexus.py
+++ b/nugraph/models/nugraph2/nexus.py
@@ -33,7 +33,7 @@ class NexusDown(MessagePassing):
             nn.Tanh())
 
     def forward(self, x: Tensor, edge_index: Tensor, n: Tensor) -> Tensor:
-        return self.propagate(x=x, n=n, edge_index=edge_index)
+        return self.propagate(edge_index=edge_index, x=x, n=n)
 
     def message(self, x_i: Tensor, n_j: Tensor) -> Tensor:
         return self.edge_net(cat((x_i, n_j), dim=-1).detach()) * n_j

--- a/nugraph/models/nugraph3/nexus.py
+++ b/nugraph/models/nugraph3/nexus.py
@@ -28,7 +28,7 @@ class NexusDown(MessagePassing):
         )
 
     def forward(self, x: Tensor, edge_index: Tensor, n: Tensor) -> Tensor:
-        return self.propagate(x=x, n=n, edge_index=edge_index)
+        return self.propagate(edge_index=edge_index, x=x, n=n)
 
     def message(self, x_i: Tensor, n_j: Tensor) -> Tensor:
         return self.edge_net(cat((x_i, n_j), dim=-1).detach()) * n_j


### PR DESCRIPTION
make a minor syntax tweak to the nexus convolution block that was causing an error under PyG 2.5. also remove a couple of defunct arguments that were throwing errors when training the NuGraph2 variant.