### PR TITLE
fix loading of test dataset

### DIFF
--- a/nugraph/data/H5DataModule.py
+++ b/nugraph/data/H5DataModule.py
@@ -56,7 +56,7 @@ class H5DataModule(LightningDataModule):
             try:
                 train_samples = f['samples/train'].asstr()[()]
                 val_samples = f['samples/validation'].asstr()[()]
-                test_samples = f['samples/validation'].asstr()[()]
+                test_samples = f['samples/test'].asstr()[()]
             except:
                 print('Sample splits not found in file! Call "generate_samples" to create them.')
                 sys.exit()


### PR DESCRIPTION
fix a bug where the validation samples were being loaded for both the validation and test datasets. in order to preserve the events in the testing dataset as described in the paper, the validation and samples have been swapped in the `NG2-paper.gnn.h5` data file. the combination of these two changes should mean that from the user's perspective, the events in the validation dataset will change while the testing dataset will remain the same.