### PR TITLE
add f1 metric

### DIFF
--- a/nugraph/nugraph/models/nugraph3/decoders/event.py
+++ b/nugraph/nugraph/models/nugraph3/decoders/event.py
@@ -38,9 +38,9 @@ class EventDecoder(nn.Module):
         }
         self.recall = tm.Recall(**metric_args)
         self.precision = tm.Precision(**metric_args)
+        self.f1 = tm.F1Score(**metric_args)
+        self.cm = tm.ConfusionMatrix(**metric_args)
         self.cm_logger = ConfusionMatrixLogger(event_classes)
-        self.cm_recall = tm.ConfusionMatrix(normalize="true", **metric_args)
-        self.cm_precision = tm.ConfusionMatrix(normalize="pred", **metric_args)
 
         # network
         self.net = nn.Linear(in_features=interaction_features,
@@ -69,11 +69,11 @@ class EventDecoder(nn.Module):
             metrics[f"event/loss-{stage}"] = loss
             metrics[f"event/recall-{stage}"] = self.recall(x, y)
             metrics[f"event/precision-{stage}"] = self.precision(x, y)
+            metrics[f"event/f1-{stage}"] = self.f1(x, y)
         if stage == "train":
             metrics["temperature/event"] = self.temp
         if stage in ["val", "test"]:
-            self.cm_recall.update(x, y)
-            self.cm_precision.update(x, y)
+            self.cm.update(x, y)
 
         # add inference output to graph object
         data["evt"].e = x.softmax(dim=1)
@@ -95,7 +95,4 @@ class EventDecoder(nn.Module):
             stage: Training stage
             epoch: Training epoch index
         """
-        self.cm_logger.log(f"event/recall-matrix-{stage}",
-                           self.cm_recall, logger, epoch)
-        self.cm_logger.log(f"event/precision-matrix-{stage}",
-                           self.cm_precision, logger, epoch)
+        self.cm_logger.log("event", stage, self.cm, logger, epoch)

--- a/nugraph/nugraph/models/nugraph3/decoders/filter.py
+++ b/nugraph/nugraph/models/nugraph3/decoders/filter.py
@@ -33,9 +33,9 @@ class FilterDecoder(nn.Module):
         metric_args = {"task": "binary"}
         self.recall = tm.Recall(**metric_args)
         self.precision = tm.Precision(**metric_args)
+        self.f1 = tm.F1Score(**metric_args)
+        self.cm = tm.ConfusionMatrix(**metric_args)
         self.cm_logger = ConfusionMatrixLogger(("noise", "signal"))
-        self.cm_recall = tm.ConfusionMatrix(normalize="true", **metric_args)
-        self.cm_precision = tm.ConfusionMatrix(normalize="pred", **metric_args)
 
         # network
         self.net = nn.Linear(hit_features, 1)
@@ -61,11 +61,11 @@ class FilterDecoder(nn.Module):
             metrics[f"filter/loss-{stage}"] = loss
             metrics[f"filter/recall-{stage}"] = self.recall(x, y)
             metrics[f"filter/precision-{stage}"] = self.precision(x, y)
+            metrics[f"filter/f1-{stage}"] = self.f1(x, y)
         if stage == "train":
             metrics["temperature/filter"] = self.temp
         if stage in ["val", "test"]:
-            self.cm_recall.update(x, y)
-            self.cm_precision.update(x, y)
+            self.cm.update(x, y)
 
         # run network and add output to graph object
         data["hit"].x_filter = x.sigmoid()
@@ -87,7 +87,4 @@ class FilterDecoder(nn.Module):
             stage: Training stage
             epoch: Training epoch index
         """
-        self.cm_logger.log(f"filter/recall-matrix-{stage}",
-                           self.cm_recall, logger, epoch)
-        self.cm_logger.log(f"filter/precision-matrix-{stage}",
-                           self.cm_precision, logger, epoch)
+        self.cm_logger.log("filter", stage, self.cm, logger, epoch)

--- a/nugraph/nugraph/models/nugraph3/decoders/semantic.py
+++ b/nugraph/nugraph/models/nugraph3/decoders/semantic.py
@@ -40,8 +40,8 @@ class SemanticDecoder(nn.Module):
         self.recall = tm.Recall(**metric_args)
         self.precision = tm.Precision(**metric_args)
         self.f1 = tm.F1Score(**metric_args)
-        self.cm_logger = ConfusionMatrixLogger(semantic_classes)
         self.cm = tm.ConfusionMatrix(**metric_args)
+        self.cm_logger = ConfusionMatrixLogger(semantic_classes)
 
         # network
         self.net = nn.Linear(hit_features, len(semantic_classes))
@@ -99,20 +99,4 @@ class SemanticDecoder(nn.Module):
             epoch: Training epoch index
         """
 
-        # compute confusion matrices
-        cm = self.cm.compute().cpu()
-        cm_recall = cm / cm.sum(dim=1)[:, None]
-        cm_recall[~cm_recall.isfinite()] = 0
-        cm_precision = cm / cm.sum(dim=0)[None, :]
-        cm_precision[~cm_precision.isfinite()] = 0
-        cm_f1 = 2 * cm / cm.sum(dim=1).outer(cm.sum(dim=0))
-        cm_f1[~cm_f1.isfinite()] = 0
-        self.cm.reset()
-
-        # log confusion matrices
-        self.cm_logger.log(f"semantic/recall-matrix-{stage}",
-                           cm_recall, logger, epoch)
-        self.cm_logger.log(f"semantic/precision-matrix-{stage}",
-                           cm_precision, logger, epoch)
-        self.cm_logger.log(f"semantic/f1-matrix-{stage}",
-                           cm_f1, logger, epoch)
+        self.cm_logger.log("semantic", stage, self.cm, logger, epoch)

--- a/nugraph/nugraph/models/nugraph3/decoders/semantic.py
+++ b/nugraph/nugraph/models/nugraph3/decoders/semantic.py
@@ -39,9 +39,9 @@ class SemanticDecoder(nn.Module):
         }
         self.recall = tm.Recall(**metric_args)
         self.precision = tm.Precision(**metric_args)
+        self.f1 = tm.F1Score(**metric_args)
         self.cm_logger = ConfusionMatrixLogger(semantic_classes)
-        self.cm_recall = tm.ConfusionMatrix(normalize="true", **metric_args)
-        self.cm_precision = tm.ConfusionMatrix(normalize="pred", **metric_args)
+        self.cm = tm.ConfusionMatrix(**metric_args)
 
         # network
         self.net = nn.Linear(hit_features, len(semantic_classes))
@@ -77,11 +77,11 @@ class SemanticDecoder(nn.Module):
             metrics[f"semantic/loss-{stage}"] = loss
             metrics[f"semantic/recall-{stage}"] = self.recall(x, y)
             metrics[f"semantic/precision-{stage}"] = self.precision(x, y)
+            metrics[f"semantic/f1-{stage}"] = self.f1(x, y)
         if stage == "train":
             metrics["temperature/semantic"] = self.temp
         if stage in ["val", "test"]:
-            self.cm_recall.update(x, y)
-            self.cm_precision.update(x, y)
+            self.cm.update(x, y)
 
         # apply softmax to prediction
         data["hit"].x_semantic = data["hit"].x_semantic.softmax(dim=1)
@@ -98,8 +98,21 @@ class SemanticDecoder(nn.Module):
             stage: Training stage
             epoch: Training epoch index
         """
-        self.cm_logger.log(f"semantic/recall-matrix-{stage}",
-                           self.cm_recall, logger, epoch)
-        self.cm_logger.log(f"semantic/precision-matrix-{stage}",
-                           self.cm_precision, logger, epoch)
 
+        # compute confusion matrices
+        cm = self.cm.compute().cpu()
+        cm_recall = cm / cm.sum(dim=1)[:, None]
+        cm_recall[~cm_recall.isfinite()] = 0
+        cm_precision = cm / cm.sum(dim=0)[None, :]
+        cm_precision[~cm_precision.isfinite()] = 0
+        cm_f1 = 2 * cm / cm.sum(dim=1).outer(cm.sum(dim=0))
+        cm_f1[~cm_f1.isfinite()] = 0
+        self.cm.reset()
+
+        # log confusion matrices
+        self.cm_logger.log(f"semantic/recall-matrix-{stage}",
+                           cm_recall, logger, epoch)
+        self.cm_logger.log(f"semantic/precision-matrix-{stage}",
+                           cm_precision, logger, epoch)
+        self.cm_logger.log(f"semantic/f1-matrix-{stage}",
+                           cm_f1, logger, epoch)

--- a/nugraph/nugraph/util/confusion_matrix_logger.py
+++ b/nugraph/nugraph/util/confusion_matrix_logger.py
@@ -1,4 +1,5 @@
 """Utility class for logging confusion matrices"""
+from torch import Tensor
 import torchmetrics as tm
 from pytorch_lightning.loggers import Logger, TensorBoardLogger, WandbLogger
 import wandb
@@ -18,14 +19,14 @@ class ConfusionMatrixLogger:
         self.classes = classes
 
 
-    def log(self, name: str, matrix: tm.ConfusionMatrix,
+    def log(self, name: str, matrix: Tensor,
             logger: Logger | list[Logger], epoch: int) -> None:
         """
         Log confusion matrix
 
         Args:
             name: Name of confusion matrix
-            matrix: Torchmetrics confusion matrix
+            matrix: Confusion matrix tensor
             logger: PyTorch Lightning logger object(s)
             epoch: Training epoch number
         """
@@ -43,23 +44,20 @@ class ConfusionMatrixLogger:
             if isinstance(logger, WandbLogger):
                 self.log_wandb(name, matrix)
 
-        matrix.reset()
 
-
-    def log_tensorboard(self, name: str, matrix: tm.ConfusionMatrix,
+    def log_tensorboard(self, name: str, matrix: Tensor,
                         logger: TensorBoardLogger, epoch: int) -> None:
         """
         Draw and log confusion matrix with Tensorboard
 
         Args:
             name: Name of confusion matrix
-            matrix: Torchmetrics confusion matrix
+            matrix: Confusion matrix tensor
             logger: Tensorboard logger
             epoch: Training epoch number
         """
-        cm = matrix.compute().cpu()
         fig = plt.figure(figsize=[8,6])
-        sn.heatmap(cm,
+        sn.heatmap(matrix,
                    xticklabels=self.classes,
                    yticklabels=self.classes,
                    vmin=0, vmax=1,
@@ -70,18 +68,17 @@ class ConfusionMatrixLogger:
         logger.experiment.add_figure(name, fig, global_step=epoch)
 
 
-    def log_wandb(self, name: str, matrix: tm.ConfusionMatrix) -> None:
+    def log_wandb(self, name: str, matrix: Tensor) -> None:
         """
         Draw and log confusion matrix with Weights and Biases
 
         Args:
             name: Name of confusion matrix
-            matrix: Torchmetrics confusion matrix
+            matrix: Confusion matrix tensor
         """
-        cm = matrix.compute().cpu()
         table = wandb.Table(columns=["plotly_figure"])
         fig = px.imshow(
-            cm, zmax=1, text_auto=True,
+            matrix, zmax=1, text_auto=True,
             labels={"x": "Predicted", "y": "True", "color": label},
             x=self.classes, y=self.classes)
         with tempfile.NamedTemporaryFile() as f:

--- a/nugraph/nugraph/util/confusion_matrix_logger.py
+++ b/nugraph/nugraph/util/confusion_matrix_logger.py
@@ -19,17 +19,19 @@ class ConfusionMatrixLogger:
         self.classes = classes
 
 
-    def log(self, name: str, matrix: Tensor,
+    def log(self, name: str, stage: str, cm: tm.ConfusionMatrix,
             logger: Logger | list[Logger], epoch: int) -> None:
         """
         Log confusion matrix
 
         Args:
-            name: Name of confusion matrix
-            matrix: Confusion matrix tensor
+            name: Decoder name
+            stage: Stage name (train/test/val)
+            cm: Torchmetrics confusion matrix
             logger: PyTorch Lightning logger object(s)
             epoch: Training epoch number
         """
+
         # create list of loggers
         if not logger:
             loggers = []
@@ -38,11 +40,28 @@ class ConfusionMatrixLogger:
         else:
             loggers = [logger]
 
-        for logger in loggers:
-            if isinstance(logger, TensorBoardLogger):
-                self.log_tensorboard(name, matrix, logger, epoch)
-            if isinstance(logger, WandbLogger):
-                self.log_wandb(name, matrix)
+        # compute confusion matrices
+        mx = cm.compute().cpu()
+        mx_recall = mx / mx.sum(dim=1)[:, None]
+        mx_precision = mx / mx.sum(dim=0)[None, :]
+        mx_f1 = 2 * mx_recall * mx_precision / (mx_precision + mx_recall)
+        cm.reset()
+
+        # build matrix dictionary
+        mxs = {
+            f"{name}/recall-matrix-{stage}": mx_recall,
+            f"{name}/precision-matrix-{stage}": mx_precision,
+            f"{name}/f1-matrix-{stage}": mx_f1,
+        }
+
+        # loop over matrices and log
+        for key, val in mxs.items():
+            val[~val.isfinite()] = 0
+            for logger in loggers:
+                if isinstance(logger, TensorBoardLogger):
+                    self.log_tensorboard(key, val, logger, epoch)
+                if isinstance(logger, WandbLogger):
+                    self.log_wandb(key, val)
 
 
     def log_tensorboard(self, name: str, matrix: Tensor,


### PR DESCRIPTION
the F1 score is the harmonic mean of the recall (efficiency) and precision (purity), which provides a balanced measure of the performance of a classification task. this PR adds F1 metric logging to the semantic, filter and event decoders, and overhauls the confusion matrix logging mechanism to add in an F1 matrix in addition to the recall and precision matrices.