### PR TITLE
add pylintrc to ignore directories

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,5 @@
+[MAIN]
+ignore=
+    docs,
+    notebooks,
+    scripts,


### PR DESCRIPTION
add a `.pylintrc` file to ignore the `docs`, `notebooks` and `scripts` directories during pylint runs, so we only lint the `nugraph` and `pynuml` modules.