### PR TITLE
Feature/remove detach main

### DIFF
--- a/nugraph/nugraph/models/nugraph2/nexus.py
+++ b/nugraph/nugraph/models/nugraph2/nexus.py
@@ -42,7 +42,7 @@ class NexusDown(MessagePassing): # pylint: disable=abstract-method
     def forward(self, x: T, edge_index: T, n: T) -> T: # pylint: disable=arguments-differ
         return self.propagate(edge_index=edge_index, x=x, n=n)
 
-    def message(self, x_i: T, n_j: T) -> T:
+    def message(self, x_i: T, n_j: T) -> T: # pylint: disable=arguments-differ
         return self.edge_net(torch.cat((x_i, n_j), dim=-1)) * n_j
 
     def update(self, aggr_out: T, x: T) -> T: # pylint: disable=arguments-differ

--- a/nugraph/nugraph/models/nugraph2/nexus.py
+++ b/nugraph/nugraph/models/nugraph2/nexus.py
@@ -42,8 +42,8 @@ class NexusDown(MessagePassing): # pylint: disable=abstract-method
     def forward(self, x: T, edge_index: T, n: T) -> T: # pylint: disable=arguments-differ
         return self.propagate(edge_index=edge_index, x=x, n=n)
 
-    def message(self, x_i: T, n_j: T) -> T: # pylint: disable=arguments-differ
-        return self.edge_net(torch.cat((x_i, n_j), dim=-1).detach()) * n_j
+    def message(self, x_i: T, n_j: T) -> T:
+        return self.edge_net(torch.cat((x_i, n_j), dim=-1)) * n_j
 
     def update(self, aggr_out: T, x: T) -> T: # pylint: disable=arguments-differ
         return self.node_net(torch.cat((x, aggr_out), dim=-1))

--- a/nugraph/nugraph/models/nugraph2/plane.py
+++ b/nugraph/nugraph/models/nugraph2/plane.py
@@ -44,7 +44,7 @@ class MessagePassing2D(MessagePassing): # pylint: disable=abstract-method
     def forward(self, x: T, edge_index: T): # pylint: disable=arguments-differ
         return self.propagate(edge_index, x=x, size=None)
 
-    def message(self, x_i: T, x_j: T) -> T:
+    def message(self, x_i: T, x_j: T): # pylint: disable=arguments-differ
         return self.edge_net(torch.cat((x_i, x_j), dim=-1)) * x_j
 
     def update(self, aggr_out: T, x: T): # pylint: disable=arguments-differ

--- a/nugraph/nugraph/models/nugraph2/plane.py
+++ b/nugraph/nugraph/models/nugraph2/plane.py
@@ -44,8 +44,8 @@ class MessagePassing2D(MessagePassing): # pylint: disable=abstract-method
     def forward(self, x: T, edge_index: T): # pylint: disable=arguments-differ
         return self.propagate(edge_index, x=x, size=None)
 
-    def message(self, x_i: T, x_j: T): # pylint: disable=arguments-differ
-        return self.edge_net(torch.cat((x_i, x_j), dim=-1).detach()) * x_j
+    def message(self, x_i: T, x_j: T) -> T:
+        return self.edge_net(torch.cat((x_i, x_j), dim=-1)) * x_j
 
     def update(self, aggr_out: T, x: T): # pylint: disable=arguments-differ
         return self.node_net(torch.cat((x, aggr_out), dim=-1))

--- a/nugraph/nugraph/models/nugraph3/core.py
+++ b/nugraph/nugraph/models/nugraph3/core.py
@@ -57,7 +57,7 @@ class NuGraphBlock(MessagePassing): # pylint: disable=abstract-method
             x_i: Edge features from target nodes
             x_j: Edge features from source nodes
         """
-        return self.edge_net(torch.cat((x_i, x_j), dim=1).detach()) * x_j
+        return self.edge_net(torch.cat((x_i, x_j), dim=1)) * x_j
 
     def update(self, aggr_out: T, x: T) -> T: # pylint: disable=arguments-differ
         """


### PR DESCRIPTION
This PR remove detach() from the edge_net. This was preventing the gradient to flow through the tensor. Based on a short test training this improves the rand score by 30%.