### PR TITLE
objcon cdist

### DIFF
--- a/nugraph/nugraph/util/ObjCondensationLoss.py
+++ b/nugraph/nugraph/util/ObjCondensationLoss.py
@@ -64,7 +64,7 @@ class ObjCondensationLoss(torch.nn.Module):
         f_centers, centers = scatter_max(f[e_h], e_p, out=f_centers)
         centers = e_h[centers]
 
-        bkg_mask = (y_i == -1) & (y_s >= 0)
+        bkg_mask = (y_i == -1)
 
         # calculate loss terms
         b = self.l_b(f, f_centers, bkg_mask, n_true)

--- a/nugraph/nugraph/util/ObjCondensationLoss.py
+++ b/nugraph/nugraph/util/ObjCondensationLoss.py
@@ -26,7 +26,7 @@ class ObjCondensationLoss(torch.nn.Module):
         q = f.float().clamp(-0.99999, 0.99999).atanh().square() + self.q_min
         m_ik = torch.zeros(n_hit, n_true, dtype=torch.bool, device=device)
         m_ik[e_h, e_p] = True
-        dist = (x[:, None, :] - x[centers][None, :, :]).square().sum(dim=2)
+        dist = torch.cdist(x, x[centers])
         v = torch.where(m_ik, dist, (1 - dist).clamp(0))
         v = ((v * q[centers]).sum(dim=1) * q).sum() / n_hit
         return v

--- a/nugraph/nugraph/util/ObjCondensationLoss.py
+++ b/nugraph/nugraph/util/ObjCondensationLoss.py
@@ -26,8 +26,9 @@ class ObjCondensationLoss(torch.nn.Module):
         q = f.float().clamp(-0.99999, 0.99999).atanh().square() + self.q_min
         m_ik = torch.zeros(n_hit, n_true, dtype=torch.bool, device=device)
         m_ik[e_h, e_p] = True
-        dist = torch.cdist(x, x[centers])
-        v = torch.where(m_ik, dist, (1 - dist).clamp(0))
+        v_a = torch.cdist(x, x[centers], p=2)
+        v_r = (1 - torch.cdist(x, x[centers], p=1)).clamp(min=0)
+        v = torch.where(m_ik, v_a, v_r)
         v = ((v * q[centers]).sum(dim=1) * q).sum() / n_hit
         return v
 

--- a/nugraph/nugraph/util/ObjCondensationLoss.py
+++ b/nugraph/nugraph/util/ObjCondensationLoss.py
@@ -26,9 +26,8 @@ class ObjCondensationLoss(torch.nn.Module):
         q = f.float().clamp(-0.99999, 0.99999).atanh().square() + self.q_min
         m_ik = torch.zeros(n_hit, n_true, dtype=torch.bool, device=device)
         m_ik[e_h, e_p] = True
-        v_a = torch.cdist(x, x[centers], p=2)
-        v_r = (1 - torch.cdist(x, x[centers], p=1)).clamp(min=0)
-        v = torch.where(m_ik, v_a, v_r)
+        dist = torch.cdist(x, x[centers])
+        v = torch.where(m_ik, dist.square(), (1-dist).clamp(min=0))
         v = ((v * q[centers]).sum(dim=1) * q).sum() / n_hit
         return v
 


### PR DESCRIPTION
update the object condensation loss to use the cdist function, and also fix a bug where the square of the L2 norm was being used for both the attractive and repulsive potentials, rather than just the attractive potential. this also keeps background hits as part of the background for clustering, rather than treating them as part of the condensation space


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>