### PR TITLE
compile NuGraph2 with JIT

### DIFF
--- a/nugraph/nugraph/models/nugraph2/decoders.py
+++ b/nugraph/nugraph/models/nugraph2/decoders.py
@@ -139,7 +139,7 @@ class SemanticDecoder(DecoderBase):
             x: Planar feature tensor dictionary
             batch: Batch index tensor dictionary
         """
-        return {'x_semantic': {p: self.net[p](x[p]).squeeze(dim=-1) for p in self.planes}}
+        return {'x_semantic': {p: net(x[p]).squeeze(dim=-1) for p, net in self.net.items()}}
 
     def arrange(self, data: NuGraphData) -> tuple[T, T]:
         x = torch.cat([data[p].x_semantic for p in self.planes], dim=0)
@@ -186,8 +186,8 @@ class FilterDecoder(DecoderBase):
             batch: Batch index tensor dictionary
         """
         ret = {}
-        for p in self.planes:
-            ret[p] = self.net[p](x[p].flatten(start_dim=1)).squeeze(dim=-1)
+        for p, net in self.net.items():
+            ret[p] = net(x[p].flatten(start_dim=1)).squeeze(dim=-1)
         return {"x_filter": ret}
 
     def arrange(self, data) -> tuple[T, T]:

--- a/nugraph/nugraph/models/nugraph2/encoder.py
+++ b/nugraph/nugraph/models/nugraph2/encoder.py
@@ -42,7 +42,7 @@ class Encoder(torch.nn.Module):
             x: Planar input tensor dictionary
         """
         ret = {}
-        for p, net in self.net.items():
-            x[p] = self.input_norm[p](x[p])
+        for (p, norm), (_, net) in zip(self.input_norm.items(), self.net.items()):
+            x[p] = norm(x[p])
             ret[p] = net(x[p].unsqueeze(1).expand(-1, self.num_classes, -1))
         return ret

--- a/nugraph/nugraph/models/nugraph2/nexus.py
+++ b/nugraph/nugraph/models/nugraph2/nexus.py
@@ -1,5 +1,4 @@
 """NuGraph2 nexus module"""
-from typing import Any, Callable
 import torch
 from torch_geometric.nn import MessagePassing, SimpleConv
 from .linear import ClassLinear
@@ -90,19 +89,6 @@ class NexusNet(torch.nn.Module):
                                            num_classes,
                                            aggr)
 
-    def ckpt(self, fn: Callable, *args) -> Any:
-        """
-        NuGraph2 nexus module checkpointing function
-
-        Args:
-            fn: Module to checkpoint
-            args: Module arguments
-        """
-        if self.checkpoint and self.training:
-            return torch.utils.checkpoint.checkpoint(fn, *args, use_reentrant=False)
-
-        return fn(*args)
-
     def forward(self, x: dict[str, T], edge_index: dict[str, T], nexus: T) -> None:
         """
         NuGraph2 nexus module forward pass
@@ -114,13 +100,20 @@ class NexusNet(torch.nn.Module):
         """
 
         # project up to nexus space
-        n = [None] * len(self.nexus_down)
+        n: list[T] = [torch.empty(0)] * len(self.nexus_down)
         for i, p in enumerate(self.nexus_down):
             n[i] = self.nexus_up(x=(x[p], nexus), edge_index=edge_index[p])
 
-        # convolve in nexus space
-        n = self.ckpt(self.nexus_net, torch.cat(n, dim=-1))
+        # convolve in nexus space; torch.jit.is_scripting() guard makes checkpoint branch dead code at compile time
+        x_cat = torch.cat(n, dim=-1)
+        if not torch.jit.is_scripting() and self.checkpoint and self.training:
+            n_cat = torch.utils.checkpoint.checkpoint(self.nexus_net, x_cat, use_reentrant=False)
+        else:
+            n_cat = self.nexus_net(x_cat)
 
         # project back down to planes
-        for p in self.nexus_down:
-            x[p] = self.ckpt(self.nexus_down[p], x[p], edge_index[p], n)
+        for p, net in self.nexus_down.items():
+            if not torch.jit.is_scripting() and self.checkpoint and self.training:
+                x[p] = torch.utils.checkpoint.checkpoint(net, x[p], edge_index[p], n_cat, use_reentrant=False)
+            else:
+                x[p] = net.forward(x[p], edge_index[p], n_cat)

--- a/nugraph/nugraph/models/nugraph2/nugraph2.py
+++ b/nugraph/nugraph/models/nugraph2/nugraph2.py
@@ -1,6 +1,7 @@
 """NuGraph2 network architecture module"""
 import argparse
 import warnings
+from typing import Dict
 
 import torch
 from pytorch_lightning import LightningModule
@@ -18,6 +19,48 @@ from ...util import InputNorm
 
 T = torch.Tensor
 TD = dict[str, T]
+
+class NuGraph2InferenceModule(torch.nn.Module):
+    """
+    Thin TorchScript-compatible wrapper around NuGraph2 for inference export.
+
+    Holds unwrapped (non-compiled) submodules and exposes a forward method
+    that can be scripted with torch.jit.script. Decoder calls are hardcoded
+    to avoid ABC/torchmetrics scripting issues.
+    """
+    planes: list[str]
+    semantic_classes: list[str]
+
+    def __init__(self, encoder, plane_net, nexus_net,
+                 semantic_decoder, filter_decoder,
+                 planes: list[str], semantic_classes: list[str], num_iters: int):
+        super().__init__()
+        self.encoder = encoder
+        self.plane_net = plane_net
+        self.nexus_net = nexus_net
+        self.semantic_decoder = semantic_decoder
+        self.filter_decoder = filter_decoder
+        self.planes = planes
+        self.semantic_classes = semantic_classes
+        self.num_iters: int = num_iters
+
+    def forward(self, x: Dict[str, torch.Tensor],
+                edge_index_plane: Dict[str, torch.Tensor],
+                edge_index_nexus: Dict[str, torch.Tensor],
+                nexus: torch.Tensor,
+                batch: Dict[str, torch.Tensor]) -> Dict[str, Dict[str, torch.Tensor]]:
+        m = self.encoder(x)
+        s = {p: x[p].detach().unsqueeze(1).expand(-1, len(self.semantic_classes), -1)
+             for p in self.planes}
+        for _ in range(self.num_iters):
+            for p in self.planes:
+                m[p] = torch.cat((m[p], s[p]), dim=-1)
+            self.plane_net(m, edge_index_plane)
+            self.nexus_net(m, edge_index_nexus, nexus)
+        ret: Dict[str, Dict[str, torch.Tensor]] = {}
+        ret.update(self.semantic_decoder(m, batch))
+        ret.update(self.filter_decoder(m, batch))
+        return ret
 
 class NuGraph2(LightningModule): # pylint: disable=too-many-instance-attributes
     """
@@ -79,7 +122,7 @@ class NuGraph2(LightningModule): # pylint: disable=too-many-instance-attributes
                                                 checkpoint=checkpoint),
                                        dynamic=True)
 
-        self.decoders = []
+        self.decoders = torch.nn.ModuleList()
 
         if semantic_head:
             self.semantic_decoder = SemanticDecoder(
@@ -212,6 +255,37 @@ class NuGraph2(LightningModule): # pylint: disable=too-many-instance-attributes
                 optimizer, max_lr=self.lr,
                 total_steps=self.trainer.estimated_stepping_batches)
         return [optimizer], {'scheduler': onecycle, 'interval': 'step'}
+
+    def export(self) -> torch.jit.ScriptModule:
+        """
+        Export a TorchScript-compatible module for inference.
+
+        Unwraps torch.compile, freezes InputNorm statistics, and returns
+        a scripted NuGraph2InferenceModule ready for torch.jit.save.
+        """
+        import copy
+
+        semantic_decoder = copy.deepcopy(self.semantic_decoder)
+        filter_decoder = copy.deepcopy(self.filter_decoder)
+
+        for decoder in (semantic_decoder, filter_decoder):
+            del decoder.recall
+            del decoder.precision
+            del decoder.cm
+            del decoder.cm_logger
+            del decoder.loss_func
+
+        m = NuGraph2InferenceModule(
+            encoder=self.encoder,
+            plane_net=self.plane_net._orig_mod,
+            nexus_net=self.nexus_net._orig_mod,
+            semantic_decoder=semantic_decoder,
+            filter_decoder=filter_decoder,
+            planes=list(self.planes),
+            semantic_classes=list(self.semantic_classes),
+            num_iters=self.num_iters)
+        m.eval()
+        return torch.jit.script(m)
 
     @staticmethod
     def transform(planes: tuple[str]) -> Transform:

--- a/nugraph/nugraph/models/nugraph2/nugraph2.py
+++ b/nugraph/nugraph/models/nugraph2/nugraph2.py
@@ -1,7 +1,7 @@
 """NuGraph2 network architecture module"""
 import argparse
 import warnings
-from typing import Dict
+import copy
 
 import torch
 from pytorch_lightning import LightningModule
@@ -44,11 +44,11 @@ class NuGraph2InferenceModule(torch.nn.Module):
         self.semantic_classes = semantic_classes
         self.num_iters: int = num_iters
 
-    def forward(self, x: Dict[str, torch.Tensor],
-                edge_index_plane: Dict[str, torch.Tensor],
-                edge_index_nexus: Dict[str, torch.Tensor],
+    def forward(self, x: dict[str, torch.Tensor],
+                edge_index_plane: dict[str, torch.Tensor],
+                edge_index_nexus: dict[str, torch.Tensor],
                 nexus: torch.Tensor,
-                batch: Dict[str, torch.Tensor]) -> Dict[str, Dict[str, torch.Tensor]]:
+                batch: dict[str, torch.Tensor]) -> dict[str, dict[str, torch.Tensor]]:
         m = self.encoder(x)
         s = {p: x[p].detach().unsqueeze(1).expand(-1, len(self.semantic_classes), -1)
              for p in self.planes}
@@ -57,7 +57,7 @@ class NuGraph2InferenceModule(torch.nn.Module):
                 m[p] = torch.cat((m[p], s[p]), dim=-1)
             self.plane_net(m, edge_index_plane)
             self.nexus_net(m, edge_index_nexus, nexus)
-        ret: Dict[str, Dict[str, torch.Tensor]] = {}
+        ret: dict[str, dict[str, torch.Tensor]] = {}
         ret.update(self.semantic_decoder(m, batch))
         ret.update(self.filter_decoder(m, batch))
         return ret
@@ -122,7 +122,7 @@ class NuGraph2(LightningModule): # pylint: disable=too-many-instance-attributes
                                                 checkpoint=checkpoint),
                                        dynamic=True)
 
-        self.decoders = torch.nn.ModuleList()
+        self.decoders = []
 
         if semantic_head:
             self.semantic_decoder = SemanticDecoder(
@@ -263,7 +263,6 @@ class NuGraph2(LightningModule): # pylint: disable=too-many-instance-attributes
         Unwraps torch.compile, freezes InputNorm statistics, and returns
         a scripted NuGraph2InferenceModule ready for torch.jit.save.
         """
-        import copy
 
         semantic_decoder = copy.deepcopy(self.semantic_decoder)
         filter_decoder = copy.deepcopy(self.filter_decoder)

--- a/nugraph/nugraph/models/nugraph2/plane.py
+++ b/nugraph/nugraph/models/nugraph2/plane.py
@@ -1,5 +1,4 @@
 """NuGraph2 planar module"""
-from typing import Any, Callable
 import torch
 from torch_geometric.nn import MessagePassing
 from .linear import ClassLinear
@@ -80,7 +79,7 @@ class PlaneNet(torch.nn.Module):
                                            num_classes,
                                            aggr)
 
-    def ckpt(self, fn: Callable, *args) -> Any:
+    def ckpt(self, fn: MessagePassing2D, x: T, edge_index: T) -> T:
         """
         NuGraph2 planar module checkpointing function
 
@@ -88,10 +87,10 @@ class PlaneNet(torch.nn.Module):
             fn: Module to checkpoint
             args: Module arguments
         """
-        if self.checkpoint and self.training:
-            return torch.utils.checkpoint.checkpoint(fn, *args, use_reentrant=False)
+        if not torch.jit.is_scripting() and self.checkpoint and self.training:
+            return torch.utils.checkpoint.checkpoint(fn, x, edge_index, use_reentrant=False)
 
-        return fn(*args)
+        return fn.forward(x, edge_index)
 
     def forward(self, x: dict[str, T], edge_index: dict[str, T]) -> None:
         """
@@ -101,5 +100,5 @@ class PlaneNet(torch.nn.Module):
             x: Planar embedding tensor dictionary
             edge_index: Edge indices within each plane
         """
-        for p in self.net:
-            x[p] = self.ckpt(self.net[p], x[p], edge_index[p])
+        for p, net in self.net.items():
+            x[p] = self.ckpt(net, x[p], edge_index[p])

--- a/nugraph/nugraph/util/input_norm.py
+++ b/nugraph/nugraph/util/input_norm.py
@@ -45,9 +45,10 @@ class InputNorm(torch.nn.Module):
             d2 = v2 + (mean - m2).square()
             var = ((n1*d1) + (n2*d2)) / n
 
-            self.norm["count"] = P(n, requires_grad=False)
-            self.norm["mean"] = P(mean, requires_grad=False)
-            self.norm["var"] = P(var, requires_grad=False)
+            self.norm["count"].copy_(n)
+            self.norm["mean"].copy_(mean)
+            self.norm["var"].copy_(var)
+
 
         # return normalized tensor
         return (x - self.norm["mean"][None, :]) / (self.norm["var"][None, :] + 1e-5).sqrt()

--- a/nugraph/nugraph/util/recall_loss.py
+++ b/nugraph/nugraph/util/recall_loss.py
@@ -29,6 +29,7 @@ class RecallLoss(torch.nn.Module):
             sync_on_compute=True  # syncs TP/FN counts across GPUs before computing recall
         )
 
+    @torch.jit.unused
     def forward(self, x: Tensor, y: Tensor) -> Tensor:
         """
         RecallLoss forward pass

--- a/scripts/compile.py
+++ b/scripts/compile.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+import argparse
+
+import torch
+import nugraph as ng
+
+def configure():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--checkpoint', type=str, required=True,
+                        help='Checkpoint file for trained NuGraph2 model')
+    parser.add_argument('--outfile', type=str, required=True,
+                        help='Output TorchScript file name (full path)')
+    return parser.parse_args()
+
+def compile(args):
+
+    print('using checkpoint =', args.checkpoint)
+    model = ng.models.NuGraph2.load_from_checkpoint(args.checkpoint, map_location='cpu')
+
+    print('exporting TorchScript module...')
+    scripted = model.export()
+
+    print('output file =', args.outfile)
+    torch.jit.save(scripted, args.outfile)
+    print('done.')
+
+if __name__ == '__main__':
+    args = configure()
+    compile(args)


### PR DESCRIPTION
This PR allows compiling a NuGraph2 model with JIT from the main branch, so that we do not need to go back to the old `cerati_jit-brute-force` branch for this task.

It adds a wrapper (`NuGraph2InferenceModule`) to nugraph2.py that holds only what JIT needs to compile and does the compilation in the export method. It also fixes various choices/conventions that don't wort with JIT, without changing the network behavior. 

Claude was used to make this PR.