### PR TITLE
bug fix: indexing in FeatureExtension to use arange instead of ones

### DIFF
--- a/nugraph/nugraph/util/feature_extension.py
+++ b/nugraph/nugraph/util/feature_extension.py
@@ -36,7 +36,7 @@ class FeatureExtension(BaseTransform):
                 edge = data['hit', 'delaunay-planar', 'hit']
                 x = data['hit'].x[idx]
             else:
-                idx = torch.ones(data[p].x.shape[0], dtype=torch.long)
+                idx = torch.arange(data[p].x.shape[0])
                 pos = data.collect("pos")[p]
                 edge = data[p, 'plane', p]
                 x = torch.cat((data[p].x, torch.zeros(data[p].x.shape[0],4)), dim=-1)


### PR DESCRIPTION
torch.ones(..., dtype=torch.long) gives every node the degree of node 1; torch.arange gives each node its own correct degree.

this only impact the nodes_degree variable if if "hit" is not in data.node_types 